### PR TITLE
fix: Naprawa ciemnego motywu

### DIFF
--- a/src/components/App/AppView.tsx
+++ b/src/components/App/AppView.tsx
@@ -13,49 +13,45 @@ import Results from 'components/Results';
 import Privacy from 'components/Privacy';
 import Error404 from 'components/Error404';
 import Team from 'components/Team';
+import ThemeProvider from './ThemeContext';
 import Footer from '../Footer';
 import { Content } from './AppStyle';
 
 const Lab = React.lazy(() => import('components/Lab'));
-export const ThemeContext = React.createContext<any>([{}, () => {}]);
 
 library.add(faBars, faTimes);
 
-const App: React.FC = () => {
-  const [theme, setTheme] = React.useState(localStorage.getItem('theme') || 'light');
-
-  return (
-    <ThemeContext.Provider value={{ theme, setTheme }}>
-      <div className={`app ${theme}`}>
-        <Helmet>
-          <title>myPolitics – Test poglądów politycznych</title>
-          <meta property="og:title" content="myPolitics – Test poglądów politycznych" />
-          <meta name="description" content="Test polityczny ukazujący twoje poglądy na siedmiu osiach." />
-          <meta property="og:description" content="Test polityczny ukazujący twoje poglądy na siedmiu osiach." />
-          <meta property="og:image" content="/images/thumbnails/mypolitics.png" />
-        </Helmet>
-        <Router>
-          <Header />
-          <Content>
-            <React.Suspense fallback={null}>
-              <Switch>
-                <Route exact path="/" component={Home} />
-                <Route path="/quiz" component={Quiz} />
-                <Route path="/results/:id" component={Results} />
-                <Route path="/history" component={ResultsHistory} />
-                <Route path="/privacy" component={Privacy} />
-                <Route path="/404" component={Error404} />
-                <Route path="/lab" component={Lab} />
-                <Route path="/team" component={Team} />
-                <Route path="*" component={Error404} />
-              </Switch>
-            </React.Suspense>
-          </Content>
-          <Footer />
-        </Router>
-      </div>
-    </ThemeContext.Provider>
-  );
-}
+const App: React.FC = () => (
+  <ThemeProvider>
+    <div className="app">
+      <Helmet>
+        <title>myPolitics – Test poglądów politycznych</title>
+        <meta property="og:title" content="myPolitics – Test poglądów politycznych" />
+        <meta name="description" content="Test polityczny ukazujący twoje poglądy na siedmiu osiach." />
+        <meta property="og:description" content="Test polityczny ukazujący twoje poglądy na siedmiu osiach." />
+        <meta property="og:image" content="/images/thumbnails/mypolitics.png" />
+      </Helmet>
+      <Router>
+        <Header />
+        <Content>
+          <React.Suspense fallback={null}>
+            <Switch>
+              <Route exact path="/" component={Home} />
+              <Route path="/quiz" component={Quiz} />
+              <Route path="/results/:id" component={Results} />
+              <Route path="/history" component={ResultsHistory} />
+              <Route path="/privacy" component={Privacy} />
+              <Route path="/404" component={Error404} />
+              <Route path="/lab" component={Lab} />
+              <Route path="/team" component={Team} />
+              <Route path="*" component={Error404} />
+            </Switch>
+          </React.Suspense>
+        </Content>
+        <Footer />
+      </Router>
+    </div>
+  </ThemeProvider>
+);
 
 export default App;

--- a/src/components/App/ThemeContext.tsx
+++ b/src/components/App/ThemeContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+type Theme = 'light' | 'dark'
+
+interface ThemeCtx {
+  theme: Theme,
+  setTheme: (theme: Theme) => void
+}
+
+const THEME_KEY = 'theme';
+const STORED_THEME = localStorage.getItem(THEME_KEY) as Theme | null;
+
+export const ThemeContext = createContext<ThemeCtx>({
+  theme: 'light',
+  setTheme: () => {},
+});
+
+const ThemeProvider: React.FC = ({ children }) => {
+  const [theme, _setTheme] = useState<Theme>(STORED_THEME || 'light');
+
+  useEffect(() => {
+    document.body.className = theme;
+  }, [theme]);
+
+  const setTheme = (newTheme: Theme) => {
+    _setTheme(newTheme);
+    localStorage.setItem(THEME_KEY, newTheme);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export default ThemeProvider;

--- a/src/components/Header/HeaderView.tsx
+++ b/src/components/Header/HeaderView.tsx
@@ -7,7 +7,7 @@ import { FontAwesomeIcon as FaIcon } from '@fortawesome/react-fontawesome';
 import './Header.scss';
 import { ReactComponent as Logo } from 'assets/vectors/logo.svg';
 import Nav from './Nav';
-import { ThemeContext } from '../App/AppView';
+import { ThemeContext } from '../App/ThemeContext';
 
 library.add(faBars, faTimes, faSun);
 

--- a/src/components/Privacy/Privacy.scss
+++ b/src/components/Privacy/Privacy.scss
@@ -18,14 +18,14 @@
     background: var(--gray-1);
     padding: 1rem;
     border-radius: 0.5rem;
-    color: #363636;
+    color: var(--black-2);
     line-height: 1.5;
     b {
       font-weight: 700;
     }
     h2,
     a {
-      color: #363636;
+      color: var(--black-2);
     }
     h2:first-child {
       margin-top: 0;

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,6 +1,7 @@
 $white: #FFF;
 $black: #000;
 $black-1: #111;
+$black-2: #363636;
 $gray-1: #FAFAFA;
 $gray-2: #F5F5F5;
 $gray-3: #ECECEC;
@@ -8,11 +9,13 @@ $blue-1: #00B3DB;
 $blue-2: #00A1C6;
 $blue-3: #00b4db;
 
-.app {
+body {
   min-height: 100vh;
+  background: var(--white);
   --white: #{$white};
   --black: #{$black};
   --black-1: #{$black-1};
+  --black-2: #{$black-2};
   --gray-1: #{$gray-1};
   --gray-2: #{$gray-2};
   --gray-3: #{$gray-3};
@@ -21,19 +24,16 @@ $blue-3: #00b4db;
   --blue-3: #{$blue-3};
 }
 
-.app, main {
-  background: var(--white);
-}
-
-.app.dark {
+body.dark {
   --white: #{invert($white)};
   --black: #{invert($black)};
   --black-1: #{invert($black-1)};
+  --black-2: #{invert($black-2)};
   --gray-1: #{invert($gray-1)};
   --gray-2: #{invert($gray-2)};
   --gray-3: #{invert($gray-3)};
-  --blue-1: #{darken($blue-1, 40%)};
-  --blue-2: #{darken($blue-2, 40%)};
+  --blue-1: #{darken($blue-1, 10%)};
+  --blue-2: #{darken($blue-2, 10%)};
   --blue-3: #{darken($white, 20%)};
 
   .home__hero__overlay {
@@ -59,4 +59,9 @@ $blue-3: #00b4db;
   img, ins {
     filter: brightness(85%);
   }
+
+  .team__list__title, .team__list__element span, .privacy__title {
+    color: var(--black);
+  }
+
 }


### PR DESCRIPTION
- Zmienne w CSS muszą być dostępne dla całej strony, a nie tylko dla diva `.app` i jego dzieci - od teraz body dostaje odpowiednią klasę
- Przeniosłem kontekst i logikę zmiany motywu do osobnego modułu, aby nie zaśmiecała komponentów
- Wprowadziłem lekkie zmiany w stylach, naprawione zostały:
- - Białe tło strony >100vh
- - Kolory plakietek "Autor" i "PR & Marketing" na stronie Team
- - Kolory tekstów na stronie Polityki Prywatności